### PR TITLE
Fix for fatal error

### DIFF
--- a/src/Service/FormAnnotationBuilderFactory.php
+++ b/src/Service/FormAnnotationBuilderFactory.php
@@ -31,8 +31,8 @@ class FormAnnotationBuilderFactory implements FactoryInterface
     {
         //setup a form factory which can use custom form elements
         $annotationBuilder = new AnnotationBuilder();
-        $eventManager       = $container->build('EventManager');
-        $annotationBuilder->setEventManager($ventManager);
+        $eventManager       = $container->get('EventManager');
+        $annotationBuilder->setEventManager($eventManager);
 
         $formElementManager = $container->get('FormElementManager');
         $formElementManager->injectFactory($container, $annotationBuilder);


### PR DESCRIPTION
Zend framework 2.5.3:

Fatal error: Uncaught Error: Call to undefined method Zend\ServiceManager\ServiceManager::build() in /data/vendor/zendframework/zend-mvc/src/Service/FormAnnotationBuilderFactory.php on line 34

Build is not a method defined on the interface passed in so shouldn't be called regardless
